### PR TITLE
Update link from unofficial nixos wiki to official one

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,7 @@ If you like nix this is a good way of doing haskell development.
 
 similar to: https://github.com/monadfix/nix-cabal
 except this has a makefile and ghcid.
-We also make aggressive use of [pinning](https://nixos.wiki/wiki/FAQ/Pinning_Nixpkgs)
+We also make aggressive use of [pinning](https://wiki.nixos.org/wiki/FAQ/Pinning_Nixpkgs)
 ensuring project builds for ever (theoretically).
 
 Comes with:


### PR DESCRIPTION
The readme references the old, unofficial wiki. This PR updates the links to point to the new official wiki source, which will be more properly maintained in the future. It's very much a fandom-wiki situation.