### PR TITLE
Add nix-shell cabal build step to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,7 @@ jobs:
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - run: nix-build
     - run: nix-shell --run "echo OK"
+    - run: nix-shell --run "cabal build"
     - name: Cancel workflow on failure
       if: failure()
       continue-on-error: true


### PR DESCRIPTION
## Summary
- Add `nix-shell --run "cabal build"` step to the nix CI job
- Verifies that cabal dependencies provided by the nix shell are sufficient to build the project

## Test plan
- [x] CI runs the new step and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)