### PR TITLE
Replace actions/cache with cache-nix-action for nix store

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,11 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Local cache
-      uses: actions/cache@v4
-      with:
-        path: /nix/store
-        key: "${{ runner.os }}-nix-cache"
     - uses: cachix/install-nix-action@v31
       with:
         nix_path: nixpkgs=channel:nixos-unstable
@@ -24,6 +19,11 @@ jobs:
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
           extra-substituters = https://nix-cache.jappie.me
           extra-trusted-public-keys = nix-cache.jappie.me:WjkKcvFtHih2i+n7bdsrJ3HuGboJiU2hA2CZbf9I9oc=
+    - name: Nix store cache
+      uses: nix-community/cache-nix-action@v6
+      with:
+        primary-key: nix-${{ hashFiles('npins/sources.json', 'nix/*.nix', '*.cabal') }}
+        restore-prefixes-first-match: nix-
     - run: nix-build
     - run: nix-shell --run "echo OK"
     - run: nix-shell --run "cabal build"


### PR DESCRIPTION
## Summary
- Replace `actions/cache@v4` on `/nix/store` with `nix-community/cache-nix-action@v6`
- Move cache step after `cachix/install-nix-action` so `/nix` exists
- Use content-addressed cache key based on `npins/sources.json`, `nix/*.nix`, and `*.cabal` hashes

The old `actions/cache` was placed before nix installation and could not write to the daemon-owned `/nix/store` anyway — tar extraction produced thousands of permission errors silently. `cache-nix-action` handles nix store permissions correctly via sudo and SQLite database merging.

## Test plan
- [ ] CI nix job passes
- [ ] Cache saved on first run (check "Post Nix store cache" step)
- [ ] Cache restored on subsequent run (check "Nix store cache" step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)