### PR TITLE
Filter source with lib.fileset

### DIFF
--- a/nix/hpkgs.nix
+++ b/nix/hpkgs.nix
@@ -1,13 +1,30 @@
 { pkgs ? import ./pkgs.nix { }
 ,
 }:
+let
+  # Decision: use lib.fileset.toSource for fine grained source filtering.
+  # Alternatives considered: passing ../. directly (rebuilds on any nix/tooling
+  # change), cleanSource (still includes too much). fileset.unions makes the
+  # build inputs explicit so editing nix/, .github/, makefile, .hlint.yaml,
+  # etc. does not invalidate the haskell build cache.
+  src = pkgs.lib.fileset.toSource {
+    root = ../.;
+    fileset = pkgs.lib.fileset.unions [
+      ../app
+      ../src
+      ../test
+      ../template.cabal
+      ../LICENSE
+      ../Readme.md
+      ../Changelog.md
+    ];
+  };
+in
 # you can pin a specific ghc version with
 # pkgs.haskell.packages.ghc984 for example.
 # this allows you to create multiple compiler targets via nix.
 pkgs.haskellPackages.override {
   overrides = hnew: hold: {
-    # NB this is a bit silly because nix files are now considered for the build
-    # bigger projects should consider putting haskell stuff in a subfolder
-    template-project = hnew.callCabal2nix "template-project" ../. { };
+    template-project = hnew.callCabal2nix "template-project" src { };
   };
 }


### PR DESCRIPTION
## Summary
- Replace `callCabal2nix "template-project" ../. {}` with an explicit `lib.fileset.toSource` that unions `app/`, `src/`, `test/`, `template.cabal`, `LICENSE`, `Readme.md`, and `Changelog.md`.
- Addresses the existing TODO note in `nix/hpkgs.nix` about nix and tooling files being considered part of the build input.
- Editing `shell.nix`, `nix/`, `.github/`, `makefile`, `.hlint.yaml`, `.stylish-haskell.yaml`, `brittany.yaml`, etc. no longer invalidates the cabal2nix-driven haskell build cache.

## Test plan
- [x] `nix-build` builds `template-1.0.0` and the unit suite (5 tests) passes locally.
- [ ] CI green on GitHub Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)