### PR TITLE
Add nix/ci.nix and enforce hlint in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       with:
         primary-key: nix-${{ hashFiles('npins/sources.json', 'nix/*.nix', '*.cabal') }}
         restore-prefixes-first-match: nix-
-    - run: nix-build
+    - run: nix-build nix/ci.nix
     - run: nix-shell --run "echo OK"
     - run: nix-shell --run "cabal build"
     - name: Cancel workflow on failure

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -1,0 +1,37 @@
+{ sources ? import ../npins
+, pkgs ? import ./pkgs.nix { inherit sources; }
+, hpkgs ? import ./hpkgs.nix { inherit pkgs; }
+,
+}:
+let
+  # The fileset filter on ../nix/hpkgs.nix already keeps the haskell
+  # build from being invalidated by edits to .hlint.yaml, so we can
+  # safely use the wider tree here without thrashing the cabal cache.
+  src = builtins.path {
+    path = ../.;
+    name = "template-project-src";
+    filter = path: _type:
+      let base = baseNameOf (toString path);
+      in !(builtins.elem base [ "dist-newstyle" "dist" "result" ".git" ]);
+  };
+in
+{
+  # The cabal build / library / executable derivation — what
+  # 'nix-build' has always built. Kept here so CI builds the project
+  # /and/ the hlint pass with a single 'nix-build nix/ci.nix' rather
+  # than two separate invocations.
+  native = import ../default.nix { inherit hpkgs; };
+
+  # Enforce .hlint.yaml across app/src/test as part of CI. Treating
+  # hlint as a derivation lets the same 'nix-build nix/ci.nix' run
+  # locally and in GitHub Actions, and keeps the hlint version pinned
+  # to the same nixpkgs as the rest of the toolchain.
+  hlint = pkgs.runCommand "ci-hlint"
+    {
+      nativeBuildInputs = [ pkgs.hlint ];
+    } ''
+    cd ${src}
+    hlint -h .hlint.yaml app src test
+    touch $out
+  '';
+}


### PR DESCRIPTION
## Summary

- New `nix/ci.nix` with two attrs: `native` (imports `default.nix`, the existing cabal build) and `hlint` (runs `hlint -h .hlint.yaml app src test` via `pkgs.runCommand`, pinning the hlint version to the project's nixpkgs).
- GHA `nix` job now runs `nix-build nix/ci.nix` instead of `nix-build`, so the hlint pass is enforced alongside the build. The matrix `cabal` job is unchanged (no nix available).
- Mirrors the pattern already used in `jappeace/mijn-webwinkel-migraine`'s `nix/ci.nix`.

## Test plan
- [x] `nix-build nix/ci.nix` builds locally — both `native` and `ci-hlint` derivations come back green; hlint reports "No hints" against the current `app`/`src`/`test` tree
- [x] `.hlint.yaml` already existed in the template; CI was just not invoking hlint
- [ ] GHA `nix` job runs `nix-build nix/ci.nix` on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)